### PR TITLE
Don't encourage the use of the get; set; syntax.

### DIFF
--- a/StyleGuide.cs
+++ b/StyleGuide.cs
@@ -45,13 +45,11 @@ namespace UD.Core
 		/// </summary>
 		public string AnExamplePublicField;
 
-		/// <summary>
-		/// Public Property
-		///		Upper case first letter
-		///		Camel Casing
-		///		Place at top of class, after private members
-		/// </summary>
-		public string PublicProperty { get; set; }
+		// /// <summary>
+		// /// Public Property
+		// /// Don't use. If you need to mutate the class, consider a method. If you need a Public Get, use the Lambda style.
+		// /// </summary>
+		// public string PublicProperty { get; set; }
 
 		/// <summary>
 		/// Getter only property


### PR DESCRIPTION
Removed public Get Set, I'd rather not promote wanton class mutation,… if we need to modify a class post initialisation, it deserves a method because it's a big deal. This accounts for so many bugs.

I don't know the best way to show this (a lack of something).  