### PR TITLE
Fix bottom contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you are interested in contributing to this project, please read through the f
 
 * [Code of Conduct](CODE_OF_CONDUCT.md)
 
-* [Contributing Guidelines](#what-should-i-know-before-i-get-started)
+* [Contributing Guidelines](.github/contributing.md)
 
 ## Licencing
 


### PR DESCRIPTION
Fixed the bottom Contributing Guidelines link - was previously linking to #what-should-i-know-before-i-get-started